### PR TITLE
Fix: Format with goimports

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,8 +19,9 @@ import (
 	jobs2 "CareerCenter/internal/usecase/jobs"
 	profile2 "CareerCenter/internal/usecase/profile"
 	"fmt"
-	"github.com/gorilla/mux"
 	"net/http"
+
+	"github.com/gorilla/mux"
 )
 
 var (

--- a/domain/entity/account/account.go
+++ b/domain/entity/account/account.go
@@ -4,8 +4,9 @@ import (
 	"CareerCenter/domain/valueobject"
 	"CareerCenter/utils"
 	"errors"
-	"github.com/google/uuid"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type Account struct {

--- a/domain/entity/application_company.go
+++ b/domain/entity/application_company.go
@@ -3,8 +3,9 @@ package entity
 import (
 	"CareerCenter/domain/entity/profile"
 	"CareerCenter/utils"
-	uuid2 "github.com/google/uuid"
 	"time"
+
+	uuid2 "github.com/google/uuid"
 )
 
 type Application struct {

--- a/domain/entity/profile/education.go
+++ b/domain/entity/profile/education.go
@@ -3,8 +3,9 @@ package profile
 import (
 	"CareerCenter/domain/valueobject"
 	"CareerCenter/utils/exceptions"
-	"github.com/google/uuid"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type Education struct {

--- a/domain/entity/profile/work_experience.go
+++ b/domain/entity/profile/work_experience.go
@@ -2,8 +2,9 @@ package profile
 
 import (
 	"CareerCenter/utils/exceptions"
-	"github.com/google/uuid"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type WorkExperience struct {

--- a/internal/config/database/mysql.go
+++ b/internal/config/database/mysql.go
@@ -4,9 +4,10 @@ import (
 	"CareerCenter/logger"
 	"database/sql"
 	"fmt"
-	_ "github.com/go-sql-driver/mysql"
 	"net/url"
 	"time"
+
+	_ "github.com/go-sql-driver/mysql"
 )
 
 func InitMysqlDB() *sql.DB {

--- a/internal/delivery/http/company/get_by_id.go
+++ b/internal/delivery/http/company/get_by_id.go
@@ -7,8 +7,9 @@ import (
 	"CareerCenter/utils/helper"
 	"context"
 	"fmt"
-	"github.com/gorilla/mux"
 	"net/http"
+
+	"github.com/gorilla/mux"
 )
 
 func (h *CompanyHandler) GetCompanyById(w http.ResponseWriter, r *http.Request) {

--- a/internal/delivery/http/jobs/get_by_id.go
+++ b/internal/delivery/http/jobs/get_by_id.go
@@ -7,8 +7,9 @@ import (
 	"CareerCenter/utils/helper"
 	"context"
 	"fmt"
-	"github.com/gorilla/mux"
 	"net/http"
+
+	"github.com/gorilla/mux"
 )
 
 func (h *JobsHandler) GetJobById(w http.ResponseWriter, r *http.Request) {

--- a/internal/delivery/http/profile/deleted_education.go
+++ b/internal/delivery/http/profile/deleted_education.go
@@ -6,8 +6,9 @@ import (
 	"CareerCenter/utils/helper"
 	"context"
 	"fmt"
-	"github.com/gorilla/mux"
 	"net/http"
+
+	"github.com/gorilla/mux"
 )
 
 func (h *ProfileHandler) DeletedEducation(w http.ResponseWriter, r *http.Request) {

--- a/internal/delivery/http/profile/deleted_work_experience.go
+++ b/internal/delivery/http/profile/deleted_work_experience.go
@@ -6,8 +6,9 @@ import (
 	"CareerCenter/utils/helper"
 	"context"
 	"fmt"
-	"github.com/gorilla/mux"
 	"net/http"
+
+	"github.com/gorilla/mux"
 )
 
 func (h *ProfileHandler) DeletedWorkExperience(w http.ResponseWriter, r *http.Request) {

--- a/internal/delivery/http/profile/update_education.go
+++ b/internal/delivery/http/profile/update_education.go
@@ -8,8 +8,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/gorilla/mux"
 	"net/http"
+
+	"github.com/gorilla/mux"
 )
 
 func (h *ProfileHandler) UpdateEducation(w http.ResponseWriter, r *http.Request) {

--- a/internal/delivery/http/profile/update_work_experience.go
+++ b/internal/delivery/http/profile/update_work_experience.go
@@ -8,8 +8,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/gorilla/mux"
 	"net/http"
+
+	"github.com/gorilla/mux"
 )
 
 func (h *ProfileHandler) UpdateWorkExperience(w http.ResponseWriter, r *http.Request) {

--- a/internal/repository/account/create_account.go
+++ b/internal/repository/account/create_account.go
@@ -6,8 +6,9 @@ import (
 	"CareerCenter/internal/repository/models"
 	"CareerCenter/utils/exceptions"
 	"context"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (r AccountMysqlInteractor) CreateAccount(ctx context.Context, data *account.Account) error {

--- a/internal/repository/account/get_by_email.go
+++ b/internal/repository/account/get_by_email.go
@@ -7,8 +7,9 @@ import (
 	"CareerCenter/utils/exceptions"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (l AccountMysqlInteractor) GetByEmail(ctx context.Context, email string) (*account.AccountDTO, error) {

--- a/internal/repository/account/get_by_email_test.go
+++ b/internal/repository/account/get_by_email_test.go
@@ -4,8 +4,9 @@ import (
 	"CareerCenter/internal/config/database"
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var (

--- a/internal/repository/account/update_password.go
+++ b/internal/repository/account/update_password.go
@@ -4,8 +4,9 @@ import (
 	"CareerCenter/internal/repository/models"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (l AccountMysqlInteractor) UpdatePassword(ctx context.Context, email string, password string) error {

--- a/internal/repository/application/get_by_email.go
+++ b/internal/repository/application/get_by_email.go
@@ -6,8 +6,9 @@ import (
 	"CareerCenter/internal/repository/models"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (a ApplicationMysqlInteractor) GetByEmail(ctx context.Context, email string, companyId string) (*entity.ApplicationDTO, error) {

--- a/internal/repository/application/send_application.go
+++ b/internal/repository/application/send_application.go
@@ -5,8 +5,9 @@ import (
 	"CareerCenter/internal/repository/mapper"
 	"CareerCenter/internal/repository/models"
 	"context"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (a ApplicationMysqlInteractor) SendApplication(ctx context.Context, application *entity.Application) error {

--- a/internal/repository/company/get_by_id.go
+++ b/internal/repository/company/get_by_id.go
@@ -6,8 +6,9 @@ import (
 	"CareerCenter/internal/repository/models"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (c CompanyMysqlInteractor) GetCompanyById(ctx context.Context, id string) (*entity.CompanyDTO, error) {

--- a/internal/repository/company/get_list_company.go
+++ b/internal/repository/company/get_list_company.go
@@ -10,8 +10,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (c CompanyMysqlInteractor) GetListCompany(ctx context.Context, typeSearch *valueobject.TypeSearch, f *filter.Filter) ([]*entity.CompanyDTO, error) {

--- a/internal/repository/jobs/get_by_company_id.go
+++ b/internal/repository/jobs/get_by_company_id.go
@@ -6,8 +6,9 @@ import (
 	"CareerCenter/internal/repository/models"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (j JobsMysqlInteractor) GetJobByCompanyId(ctx context.Context, id string) ([]*entity.JobsDTO, error) {

--- a/internal/repository/jobs/get_by_id.go
+++ b/internal/repository/jobs/get_by_id.go
@@ -6,8 +6,9 @@ import (
 	"CareerCenter/internal/repository/models"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (j JobsMysqlInteractor) GetJobById(ctx context.Context, id string) (*entity.JobsDTO, error) {

--- a/internal/repository/jobs/get_list_jobs.go
+++ b/internal/repository/jobs/get_list_jobs.go
@@ -10,8 +10,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (j JobsMysqlInteractor) GetListJobs(ctx context.Context, typeSearch *valueobject.TypeSearch, f *filter.Filter) ([]*entity.JobsDTO, error) {

--- a/internal/repository/mapper/account.go
+++ b/internal/repository/mapper/account.go
@@ -4,6 +4,7 @@ import (
 	"CareerCenter/domain/entity/account"
 	"CareerCenter/domain/valueobject"
 	"CareerCenter/internal/repository/models"
+
 	"github.com/rocketlaunchr/dbq/v2"
 )
 

--- a/internal/repository/mapper/application.go
+++ b/internal/repository/mapper/application.go
@@ -3,6 +3,7 @@ package mapper
 import (
 	"CareerCenter/domain/entity"
 	"CareerCenter/internal/repository/models"
+
 	"github.com/rocketlaunchr/dbq/v2"
 )
 

--- a/internal/repository/mapper/profile/education.go
+++ b/internal/repository/mapper/profile/education.go
@@ -4,6 +4,7 @@ import (
 	"CareerCenter/domain/entity/profile"
 	"CareerCenter/domain/valueobject"
 	profile2 "CareerCenter/internal/repository/models/profile"
+
 	"github.com/rocketlaunchr/dbq/v2"
 )
 

--- a/internal/repository/mapper/profile/profile.go
+++ b/internal/repository/mapper/profile/profile.go
@@ -4,6 +4,7 @@ import (
 	"CareerCenter/domain/entity/profile"
 	profile2 "CareerCenter/internal/repository/models/profile"
 	"CareerCenter/utils"
+
 	"github.com/rocketlaunchr/dbq/v2"
 )
 

--- a/internal/repository/mapper/profile/work_experience.go
+++ b/internal/repository/mapper/profile/work_experience.go
@@ -3,6 +3,7 @@ package profile
 import (
 	"CareerCenter/domain/entity/profile"
 	profile2 "CareerCenter/internal/repository/models/profile"
+
 	"github.com/rocketlaunchr/dbq/v2"
 )
 

--- a/internal/repository/profile/create_education.go
+++ b/internal/repository/profile/create_education.go
@@ -5,8 +5,9 @@ import (
 	profile2 "CareerCenter/internal/repository/mapper/profile"
 	profile3 "CareerCenter/internal/repository/models/profile"
 	"context"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (p ProfileMysqlInteractor) CreateEducation(ctx context.Context, education *profile.Education) error {

--- a/internal/repository/profile/create_profile.go
+++ b/internal/repository/profile/create_profile.go
@@ -5,8 +5,9 @@ import (
 	profile2 "CareerCenter/internal/repository/mapper/profile"
 	profile3 "CareerCenter/internal/repository/models/profile"
 	"context"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (p ProfileMysqlInteractor) CreateProfile(ctx context.Context, data *profile.ProfileUser) error {

--- a/internal/repository/profile/create_work_experience.go
+++ b/internal/repository/profile/create_work_experience.go
@@ -5,8 +5,9 @@ import (
 	profile2 "CareerCenter/internal/repository/mapper/profile"
 	profile3 "CareerCenter/internal/repository/models/profile"
 	"context"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (p ProfileMysqlInteractor) CreateWorkExperience(ctx context.Context, workExp *profile.WorkExperience) error {

--- a/internal/repository/profile/deleted_education.go
+++ b/internal/repository/profile/deleted_education.go
@@ -4,8 +4,9 @@ import (
 	"CareerCenter/internal/repository/models/profile"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (p ProfileMysqlInteractor) DeletedEducation(ctx context.Context, id string) error {

--- a/internal/repository/profile/deleted_work_experience.go
+++ b/internal/repository/profile/deleted_work_experience.go
@@ -4,8 +4,9 @@ import (
 	"CareerCenter/internal/repository/models/profile"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (p ProfileMysqlInteractor) DeletedWorkExperience(ctx context.Context, id string) error {

--- a/internal/repository/profile/get_list_education.go
+++ b/internal/repository/profile/get_list_education.go
@@ -6,8 +6,9 @@ import (
 	profile2 "CareerCenter/internal/repository/models/profile"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (p ProfileMysqlInteractor) GetListEducation(ctx context.Context, email string) ([]*profile.EducationDTO, error) {

--- a/internal/repository/profile/get_list_work_experience.go
+++ b/internal/repository/profile/get_list_work_experience.go
@@ -6,8 +6,9 @@ import (
 	profile2 "CareerCenter/internal/repository/models/profile"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (p ProfileMysqlInteractor) GetListWorkExperience(ctx context.Context, email string) ([]*profile.WorkExperienceDTO, error) {

--- a/internal/repository/profile/get_profile_by_email.go
+++ b/internal/repository/profile/get_profile_by_email.go
@@ -6,8 +6,9 @@ import (
 	profile3 "CareerCenter/internal/repository/models/profile"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (p ProfileMysqlInteractor) GetProfileByEmail(ctx context.Context, email string) (*profile.ProfileUserDTO, error) {

--- a/internal/repository/profile/get_profile_by_email_test.go
+++ b/internal/repository/profile/get_profile_by_email_test.go
@@ -4,9 +4,10 @@ import (
 	"CareerCenter/domain/entity/profile"
 	"CareerCenter/internal/config/database"
 	"context"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestProfileMysqlInteractor_GetProfileByEmail(t *testing.T) {

--- a/internal/repository/profile/update_ability.go
+++ b/internal/repository/profile/update_ability.go
@@ -4,8 +4,9 @@ import (
 	"CareerCenter/internal/repository/models/profile"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (p ProfileMysqlInteractor) UpdateAbility(ctx context.Context, email string, ability string) error {

--- a/internal/repository/profile/update_cv_resume.go
+++ b/internal/repository/profile/update_cv_resume.go
@@ -4,8 +4,9 @@ import (
 	"CareerCenter/internal/repository/models/profile"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (p ProfileMysqlInteractor) UpdateCvResume(ctx context.Context, email string, path string) error {

--- a/internal/repository/profile/update_education.go
+++ b/internal/repository/profile/update_education.go
@@ -5,8 +5,9 @@ import (
 	profile2 "CareerCenter/internal/repository/models/profile"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (p ProfileMysqlInteractor) UpdateEducation(ctx context.Context, id string, education *profile.Education) error {

--- a/internal/repository/profile/update_language.go
+++ b/internal/repository/profile/update_language.go
@@ -4,8 +4,9 @@ import (
 	"CareerCenter/internal/repository/models/profile"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (p ProfileMysqlInteractor) UpdateLanguage(ctx context.Context, email string, language string) error {

--- a/internal/repository/profile/update_photo.go
+++ b/internal/repository/profile/update_photo.go
@@ -4,8 +4,9 @@ import (
 	"CareerCenter/internal/repository/models/profile"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (p ProfileMysqlInteractor) UpdatePhotoProfile(ctx context.Context, email string, path string) error {

--- a/internal/repository/profile/update_portofolio.go
+++ b/internal/repository/profile/update_portofolio.go
@@ -4,8 +4,9 @@ import (
 	"CareerCenter/internal/repository/models/profile"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (p ProfileMysqlInteractor) UpdatePortofolio(ctx context.Context, email string, path string) error {

--- a/internal/repository/profile/update_profile.go
+++ b/internal/repository/profile/update_profile.go
@@ -5,8 +5,9 @@ import (
 	profile2 "CareerCenter/internal/repository/models/profile"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (p ProfileMysqlInteractor) UpdateProfile(ctx context.Context, email string, data *profile.ProfileUser) error {

--- a/internal/repository/profile/update_work_experience.go
+++ b/internal/repository/profile/update_work_experience.go
@@ -5,8 +5,9 @@ import (
 	profile2 "CareerCenter/internal/repository/models/profile"
 	"context"
 	"fmt"
-	"github.com/rocketlaunchr/dbq/v2"
 	"time"
+
+	"github.com/rocketlaunchr/dbq/v2"
 )
 
 func (p ProfileMysqlInteractor) UpdateWorkExperience(ctx context.Context, id string, workExp *profile.WorkExperience) error {

--- a/internal/usecase/account/update_password_test.go
+++ b/internal/usecase/account/update_password_test.go
@@ -9,8 +9,9 @@ import (
 	"CareerCenter/utils"
 	"CareerCenter/utils/exceptions"
 	"context"
-	"github.com/stretchr/testify/mock"
 	"testing"
+
+	"github.com/stretchr/testify/mock"
 )
 
 func TestUseCaseAccountInteractor_UpdatePassword(t *testing.T) {

--- a/internal/usecase/profile/deleted_education.go
+++ b/internal/usecase/profile/deleted_education.go
@@ -2,6 +2,7 @@ package profile
 
 import (
 	"context"
+
 	"github.com/google/uuid"
 )
 

--- a/internal/usecase/profile/deleted_work_experience.go
+++ b/internal/usecase/profile/deleted_work_experience.go
@@ -2,6 +2,7 @@ package profile
 
 import (
 	"context"
+
 	"github.com/google/uuid"
 )
 

--- a/internal/usecase/profile/get_profile_by_email_test.go
+++ b/internal/usecase/profile/get_profile_by_email_test.go
@@ -5,9 +5,10 @@ import (
 	"CareerCenter/domain/mocks"
 	"CareerCenter/testdata"
 	"context"
-	"github.com/stretchr/testify/mock"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/mock"
 )
 
 func TestUseCaseProfileInteractor_GetProfileByEmail(t *testing.T) {

--- a/internal/usecase/profile/update_education.go
+++ b/internal/usecase/profile/update_education.go
@@ -3,6 +3,7 @@ package profile
 import (
 	"CareerCenter/domain/entity/profile"
 	"context"
+
 	"github.com/google/uuid"
 )
 

--- a/internal/usecase/profile/update_work_experience.go
+++ b/internal/usecase/profile/update_work_experience.go
@@ -3,6 +3,7 @@ package profile
 import (
 	"CareerCenter/domain/entity/profile"
 	"context"
+
 	"github.com/google/uuid"
 )
 

--- a/testdata/profile.go
+++ b/testdata/profile.go
@@ -4,8 +4,9 @@ import (
 	"CareerCenter/domain/entity/profile"
 	"CareerCenter/domain/valueobject"
 	"CareerCenter/utils"
-	uuid2 "github.com/google/uuid"
 	"time"
+
+	uuid2 "github.com/google/uuid"
 )
 
 func TestDataProfile(countWorkExperiencet int, countEducation int) *profile.ProfileUserDTO {

--- a/utils/common.go
+++ b/utils/common.go
@@ -3,12 +3,13 @@ package utils
 import (
 	"CareerCenter/utils/exceptions"
 	"encoding/json"
-	"github.com/google/uuid"
-	"golang.org/x/crypto/bcrypt"
 	"math/rand"
 	"net/mail"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func ValitEmail(email string) bool {

--- a/utils/jwt_token.go
+++ b/utils/jwt_token.go
@@ -4,10 +4,11 @@ import (
 	"CareerCenter/domain/valueobject"
 	"CareerCenter/utils/exceptions"
 	"fmt"
-	"github.com/golang-jwt/jwt/v4"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/golang-jwt/jwt/v4"
 )
 
 type User struct {


### PR DESCRIPTION
Format import using [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports). For consistent import arrangement. 

I use goimports and [gopls](https://pkg.go.dev/golang.org/x/tools/gopls) `source.organizeImports` action for adding called but unimported modules. Both tools arrange import in this order:

- local modules
- stdlib
- external lib

This just for convenient and consistency, you can reject this PR. 

Btw, I'll be contributing more as requested by Mahrus. 